### PR TITLE
Improve NVMe provisioner planning output and result handling

### DIFF
--- a/provision/mounts.py
+++ b/provision/mounts.py
@@ -38,7 +38,7 @@ def _umount_all(paths: list[str]):
     udev_settle()
 
 def mount_targets(device: str, dry_run: bool=False, destructive: bool=True) -> Mounts:
-    dm: DeviceMap = probe(device, read_only=dry_run)
+    dm: DeviceMap = probe(device, dry_run=dry_run)
     mnt = "/mnt/nvme"
     boot = f"{mnt}/boot"
     esp = f"{boot}/firmware"


### PR DESCRIPTION
## Summary
- enrich plan/dry-run output with device state, planned steps, and logging helpers while emitting both preboot and completion RESULT records
- ensure mount probing and rsync synchronization respect dry-run, exclude-boot, and heartbeat installation expectations
- install the full postboot heartbeat script instead of the minimal recovery stub during provisioning and postcheck flows

## Testing
- python -m provision.cli --help
- python -m provision --help
- python -m provision.cli /dev/null --plan


------
https://chatgpt.com/codex/tasks/task_e_68e4be9b5e6c832f8263f694cb15ee1d