### PR TITLE
Detect existing VG names when mounting

### DIFF
--- a/provision/model.py
+++ b/provision/model.py
@@ -26,6 +26,7 @@ class DeviceMap:
     luks_name: str = "cryptroot"
     vg: str = "rp5vg"
     lv: str = "root"
+    root_lv_path: str | None = None
 
 @dataclass
 class Mounts:


### PR DESCRIPTION
## Summary
- derive the active volume group and logical volume names from lsblk output when probing a device
- carry the detected mapper path through the device map so mount helpers can use it directly
- guard the vgchange activation step so it only runs when a volume group name is available

## Testing
- python -m compileall provision/devices.py provision/mounts.py provision/model.py

------
https://chatgpt.com/codex/tasks/task_e_68e4cee181c4832f9980d631d78482db