### PR TITLE
Capture discard-aware lsblk output in plan state

### DIFF
--- a/04_ARTIFACTS/PLAN_SAMPLE.json
+++ b/04_ARTIFACTS/PLAN_SAMPLE.json
@@ -39,8 +39,24 @@
   },
   "state": {
     "root_source": "/dev/sda2",
-    "holders": ["nvme0n1     disk", "nvme0n1p1 part", "nvme0n1p2 part", "nvme0n1p3 part"],
-    "lsblk": ["NAME          SIZE TYPE MOUNTPOINT", "nvme0n1     238.5G disk", "nvme0n1p1  256M part /boot/efi", "Nvme0n1p2  512M part /boot", "nvme0n1p3 237.7G part", "rp5vg-root 237.2G lvm"],
+    "holders": [
+      "nvme0n1     disk",
+      "nvme0n1p1 part",
+      "nvme0n1p2 part",
+      "nvme0n1p3 part"
+    ],
+    "lsblk": [
+      "NAME             TYPE    SIZE RO DISC-ALN DISC-GRAN DISC-MAX DISC-ZERO MOUNTPOINT",
+      "sda              disk   28.9G  0        0        0B       0B         0 ",
+      "\u251c\u2500sda1           part    255M  0        0        0B       0B         0 /boot/firmware",
+      "\u2514\u2500sda2           part   28.7G  0        0        0B       0B         0 /",
+      "nvme0n1          disk  238.5G  0        0      512B       2T         0 ",
+      "\u251c\u2500nvme0n1p1      part    256M  0        0      512B       2T         0 /mnt/nvme/boot/firmware",
+      "\u251c\u2500nvme0n1p2      part    512M  0        0      512B       2T         0 /mnt/nvme/boot",
+      "\u2514\u2500nvme0n1p3      part  237.7G  0        0      512B       2T         0 ",
+      "  \u2514\u2500cryptroot    crypt 237.7G  0        0        0B       0B         0 ",
+      "    \u2514\u2500rp5vg-root lvm   237.7G  0        0        0B       0B         0 "
+    ],
     "lsblk_verbose": "ALIGNMENT ID-LINK                               ID                               DISC-ALN DAX DISC-GRAN DISK-SEQ DISC-MAX DISC-ZERO FSAVAIL FSROOTS FSSIZE FSTYPE      FSUSED FSUSE% FSVER GROUP HCTL HOTPLUG KNAME     LABEL   LOG-SEC MAJ:MIN MAJ MIN MIN-IO MODE       MODEL  MQ NAME        OPT-IO OWNER PARTFLAGS PARTLABEL PARTN PARTTYPE                             PARTTYPENAME     PARTUUID                             PATH           PHY-SEC PKNAME  PTTYPE PTUUID                                RA RAND     REV RM RO ROTA RQ-SIZE SCHED SERIAL                 SIZE   START STATE SUBSYSTEMS              MOUNTPOINT MOUNTPOINTS TRAN   TYPE UUID                                 VENDOR WSAME WWN                                                                    ZONED ZONE-SZ ZONE-WGRAN ZONE-APP ZONE-NR ZONE-OMAX ZONE-AMAX\n        0 nvme-ORICO_VCYPH6UP7QLYJDOFL15J       ORICO_VCYPH6UP7QLYJDOFL15J              0   0      512B       25       2T         0                                                        disk             0 nvme0n1               512 259:0   259 0      512 brw-rw---- ORICO   4 nvme0n1          0 root                                                                                                                       /dev/nvme0n1       512         gpt    0d23da3b-f890-410e-a6be-d7ed36c977e0 128    0 SN15098  0  0    0    1023 none  VCYPH6UP7QLYJDOFL15J 238.5G         live  block:nvme:pci:platform                        nvme   disk                                                0B nvme.1e4b-564359504836555037514c594a444f464c31354a-4f5249434f-00000001 none       0B         0B       0B       0         0         0\n        0 nvme-ORICO_VCYPH6UP7QLYJDOFL15J-part1 ORICO_VCYPH6UP7QLYJDOFL15J-part1        0   0      512B       25       2T         0                        vfat                      FAT16 disk             0 nvme0n1p1 EFI         512 259:1   259 1      512 brw-rw----         4 \u251c\u2500nvme0n1p1      0 root                          1 c12a7328-f81f-11d2-ba4b-00a0c93ec93b EFI System       75f35e5f-cfb6-4f9a-8b8b-e689daf86ce8 /dev/nvme0n1p1     512 nvme0n1 gpt    0d23da3b-f890-410e-a6be-d7ed36c977e0 128    0          0  0    0    1023 none                         256M    2048       block:nvme:pci:platform                        nvme   part A0F0-7F22                                      0B nvme.1e4b-564359504836555037514c594a444f464c31354a-4f5249434f-00000001 none       0B         0B       0B       0         0         0\n        0 nvme-ORICO_VCYPH6UP7QLYJDOFL15J-part2 ORICO_VCYPH6UP7QLYJDOFL15J-part2        0   0      512B       25       2T         0                        ext4                      1.0   disk             0 nvme0n1p2 boot        512 259:2   259 2      512 brw-rw----         4 \u251c\u2500nvme0n1p2      0 root                          2 0fc63daf-8483-4772-8e79-3d69d8477de4 Linux filesystem 8b875c5c-8725-463d-a52d-0856ef3b9744 /dev/nvme0n1p2     512 nvme0n1 gpt    0d23da3b-f890-410e-a6be-d7ed36c977e0 128    0          0  0    0    1023 none                         512M  526336       block:nvme:pci:platform                        nvme   part 9166caa8-af9e-4958-9fcc-395347548735           0B nvme.1e4b-564359504836555037514c594a444f464c31354a-4f5249434f-00000001 none       0B         0B       0B       0         0         0\n        0 nvme-ORICO_VCYPH6UP7QLYJDOFL15J-part3 ORICO_VCYPH6UP7QLYJDOFL15J-part3        0   0      512B       25       2T         0                        crypto_LUKS               2     disk             0 nvme0n1p3 rp5root     512 259:3   259 3      512 brw-rw----         4 \u2514\u2500nvme0n1p3      0 root                          3 ca7d7ccb-63ed-4c53-861c-1742536059cc                  31df4115-961b-41e0-b8dc-147ae94f28bf /dev/nvme0n1p3     512 nvme0n1 gpt    0d23da3b-f890-410e-a6be-d7ed36c977e0 128    0          0  0    0    1023 none                       237.7G 1574912       block:nvme:pci:platform                        nvme   part 79fa4cf3-5ff1-4fc8-899e-9f0abbea47c5           0B nvme.1e4b-564359504836555037514c594a444f464c31354a-4f5249434f-00000001 none       0B         0B       0B       0         0         0",
     "same_underlying_disk": false
   },
@@ -74,4 +90,3 @@
   "timestamp": 1759837918,
   "artifact": "/root/rp5/03_LOGS/plan_20251007_045158.json"
 }
- 

--- a/04_ARTIFACTS/USB_OS_SETUP.md
+++ b/04_ARTIFACTS/USB_OS_SETUP.md
@@ -3,7 +3,7 @@
 apt-get update && apt-get -y full-upgrade
 apt-get install -y cryptsetup-initramfs lvm2 rsync parted dosfstools jq python3
 
-lsblk -o NAME,SIZE,TYPE,MOUNTPOINTS
+lsblk -o NAME,TYPE,SIZE,RO,DISC-ALN,DISC-GRAN,DISC-MAX,DISC-ZERO,MOUNTPOINT
 python3 provision/go.py initramfs --distro auto --rebuild-all || true
 provision/nvme_esp_fix.sh /dev/nvme0n1 /boot/firmware
 provision/ete_run.sh

--- a/provision/cli.py
+++ b/provision/cli.py
@@ -168,9 +168,18 @@ def _plan_payload(plan: ProvisionPlan, flags: Flags, root_src: str) -> Dict[str,
     holders = _holders_snapshot(plan.device)
     state["holders"] = holders
     try:
-        lsblk = run(["lsblk", "-o", "NAME,SIZE,TYPE,MOUNTPOINT", plan.device], check=False)
-        if getattr(lsblk, "out", "").strip():
-            state["lsblk"] = lsblk.out.strip()
+        lsblk = run(
+            [
+                "lsblk",
+                "-o",
+                "NAME,TYPE,SIZE,RO,DISC-ALN,DISC-GRAN,DISC-MAX,DISC-ZERO,MOUNTPOINT",
+                plan.device,
+            ],
+            check=False,
+        )
+        out = (getattr(lsblk, "out", "") or "").strip()
+        if out:
+            state["lsblk"] = out.splitlines()
     except Exception:
         pass
     try:


### PR DESCRIPTION
## Summary
- capture lsblk output with discard-related columns when generating plan state
- normalize stored lsblk output into line-by-line arrays for easier reading
- refresh documentation and sample plan artifact to reflect the new lsblk invocation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e50a1fcf10832f9f035a3db1667062