### PR TITLE
Adjust CLI and tests for simplified mount helpers

### DIFF
--- a/provision/mounts.py
+++ b/provision/mounts.py
@@ -1,629 +1,120 @@
 """Mount helpers (Phase 5.1)."""
-from subprocess import CalledProcessError
-import contextlib
-import os
-import stat
-import time
-
-from .model import Mounts, DeviceMap
+from .model import Mounts
 from .executil import run, udev_settle, trace
 from .devices import probe
 
-
-class MkfsError(RuntimeError):
-    """Raised when destructive formatting fails or is unsafe."""
-
-    def __init__(self, message: str, *, state: dict | None = None) -> None:
-        super().__init__(message)
-        self.state = state or {}
-
-
-def _blkid_type(path: str) -> str:
-    r = run(["blkid", "-s", "TYPE", "-o", "value", path], check=False)
+def _blkid(path: str) -> str:
+    r = run(["blkid","-s","TYPE","-o","value", path], check=False)
     return (r.out or "").strip()
 
-
-def _device_realpath(dev: str) -> str:
-    try:
-        return os.path.realpath(dev)
-    except OSError:
-        return dev
-
-
-def _device_name(dev: str) -> str:
-    return os.path.basename(_device_realpath(dev))
-
-
-def _read_int(path: str) -> int | None:
-    try:
-        with open(path, "r", encoding="utf-8") as fh:
-            text = fh.read().strip()
-    except FileNotFoundError:
-        return None
-    except OSError as exc:  # noqa: PERF203 - capture unexpected sysfs errors
-        trace("mounts.sysfs_read_error", path=path, error=str(exc))
-        return None
-    if not text:
-        return None
-    try:
-        return int(text)
-    except ValueError:
-        trace("mounts.sysfs_parse_error", path=path, raw=text)
-        return None
-
-
-def _device_discard_capabilities(dev: str) -> dict:
-    name = _device_name(dev)
-    queue_dir = os.path.join("/sys/class/block", name, "queue")
-    max_bytes = _read_int(os.path.join(queue_dir, "discard_max_bytes"))
-    granularity = _read_int(os.path.join(queue_dir, "discard_granularity"))
-    zeroes = _read_int(os.path.join(queue_dir, "discard_zeroes_data"))
-    capabilities: dict[str, int | bool | None] = {
-        "discard_max_bytes": max_bytes,
-        "discard_granularity": granularity,
-    }
-    if zeroes is not None:
-        capabilities["discard_zeroes_data"] = bool(zeroes)
-    capabilities["supports_discard"] = bool(max_bytes and max_bytes > 0)
-    return capabilities
-
-
-def _device_ro(dev: str) -> bool:
-    name = _device_name(dev)
-    ro_path = os.path.join("/sys/class/block", name, "ro")
-    try:
-        with open(ro_path, "r", encoding="utf-8") as fh:
-            return fh.read().strip() == "1"
-    except FileNotFoundError:
-        return False
-    except OSError as exc:  # noqa: PERF203 - trace unexpected sysfs failures
-        trace("mounts.preflight.ro_error", device=dev, path=ro_path, error=str(exc))
-        return False
-
-
-def _device_mountpoints(dev: str) -> list[str]:
-    mountpoints: list[str] = []
-    real = _device_realpath(dev)
-    try:
-        with open("/proc/self/mountinfo", "r", encoding="utf-8") as fh:
-            for line in fh:
-                parts = line.strip().split()
-                if not parts:
-                    continue
-                with contextlib.suppress(ValueError):
-                    dash = parts.index("-")
-                    source_idx = dash + 2
-                    if source_idx >= len(parts):
-                        continue
-                    source = parts[source_idx]
-                    if not source:
-                        continue
-                    try:
-                        src_real = os.path.realpath(source)
-                    except OSError:
-                        src_real = source
-                    if src_real == real:
-                        mount_point = parts[4].replace("\\040", " ")
-                        mountpoints.append(mount_point)
-    except FileNotFoundError:
-        return []
-    except OSError as exc:  # noqa: PERF203 - ensure unexpected failures get surfaced via trace
-        trace("mounts.preflight.mountinfo_error", device=dev, error=str(exc))
-    return mountpoints
-
-
-def _device_holders(dev: str) -> list[str]:
-    name = _device_name(dev)
-    holders_dir = os.path.join("/sys/class/block", name, "holders")
-    try:
-        return sorted(os.listdir(holders_dir))
-    except FileNotFoundError:
-        return []
-    except OSError as exc:  # noqa: PERF203 - diagnostic trace
-        trace("mounts.preflight.holders_error", device=dev, path=holders_dir, error=str(exc))
-        return []
-
-
-def _dmsetup_open_count(dev: str) -> int | None:
-    candidates = [_device_realpath(dev), _device_name(dev)]
-    for candidate in candidates:
-        if not candidate:
-            continue
-        try:
-            result = run(["dmsetup", "info", "-c", "--noheadings", "-o", "open", candidate], check=False)
-        except FileNotFoundError:
-            trace("mounts.preflight.dmsetup_missing")
-            return None
-        if result.rc == 0 and result.out:
-            text = result.out.strip().splitlines()[-1]
-            try:
-                return int(text)
-            except ValueError:
-                trace("mounts.preflight.dmsetup_parse_error", device=dev, raw=text)
-                return None
-    return None
-
-
-def _collect_device_state(dev: str) -> dict:
-    state = {
-        "device": dev,
-        "realpath": _device_realpath(dev),
-        "read_only": _device_ro(dev),
-        "mountpoints": _device_mountpoints(dev),
-        "holders": _device_holders(dev),
-    }
-    discard = _device_discard_capabilities(dev)
-    if discard:
-        state["discard_capabilities"] = discard
-    open_count = _dmsetup_open_count(dev)
-    if open_count is not None:
-        state["dmsetup_open_count"] = open_count
-    return state
-
-
-def _preflight_errors(state: dict) -> list[str]:
-    errors: list[str] = []
-    if state.get("read_only"):
-        errors.append("device is read-only")
-    mountpoints = state.get("mountpoints") or []
-    if mountpoints:
-        mounts = ", ".join(sorted(mountpoints))
-        errors.append(f"device is mounted at {mounts}")
-    holders = state.get("holders") or []
-    if holders:
-        errors.append(f"device has holders: {', '.join(holders)}")
-    open_count = state.get("dmsetup_open_count")
-    if isinstance(open_count, int) and open_count > 0:
-        errors.append(f"dmsetup open count is {open_count}")
-    return errors
-
-
-def _dd_zero_first_megabytes(dev: str, count: int = 8) -> dict:
-    args = [
-        "dd",
-        "if=/dev/zero",
-        f"of={dev}",
-        "bs=1M",
-        f"count={count}",
-        "conv=fsync",
-    ]
-    result = run(args, check=False, timeout=max(120.0, count * 2.0))
-    info = {
-        "args": args,
-        "rc": result.rc,
-        "stdout": (result.out or "").strip(),
-        "stderr": (result.err or "").strip(),
-    }
-    trace(
-        "mounts.dd_zero", device=dev, rc=result.rc, stderr=info["stderr"], stdout=info["stdout"]
-    )
-    return info
-
-
-def _wipe_device(dev: str, *, discard: bool = True) -> dict:
-    wipe_info: dict[str, object] = {
-        "discard_capabilities": _device_discard_capabilities(dev),
-    }
-
-    def _run_wipefs(*extra_args: str) -> None:
-        result = run(["wipefs", "-a", *extra_args, dev], check=True, timeout=120.0)
-        wipe_info["wipefs"] = {
-            "args": ["wipefs", "-a", *extra_args, dev],
-            "rc": result.rc,
-            "stdout": (result.out or "").strip(),
-            "stderr": (result.err or "").strip(),
-        }
-
-    try:
-        _run_wipefs()
-    except CalledProcessError as exc:
-        msg = (exc.stderr or exc.stdout or "").strip() or f"exit status {exc.returncode}"
-        # ``wipefs`` occasionally reports ``cannot flush modified buffers`` on
-        # freshly created device-mapper nodes.  The metadata wipes succeed but
-        # the follow-up flush fails while udev is still settling, causing the
-        # provisioning flow to abort.  Retry with ``--no-sync`` so ``wipefs``
-        # skips the flush step in this specific scenario.  Keep the fallback
-        # narrowly scoped to avoid masking other unexpected errors.
-        if "cannot flush modified buffers" in msg.lower():
-            trace("mounts.wipefs_retry_no_sync", device=dev, message=msg)
-            try:
-                _run_wipefs("--no-sync")
-            except CalledProcessError:
-                raise MkfsError(
-                    f"wipefs failed on {dev}: {msg}",
-                    state=_collect_device_state(dev),
-                ) from exc
-            else:
-                trace("mounts.wipefs_retry_no_sync_success", device=dev)
-                msg = None
-        if msg:
-            raise MkfsError(
-                f"wipefs failed on {dev}: {msg}",
-                state=_collect_device_state(dev),
-            ) from exc
-    if not discard:
-        return wipe_info
-
-    capabilities = wipe_info.get("discard_capabilities") or {}
-    supports_discard = bool(capabilities.get("supports_discard"))
-    discard_args = ["blkdiscard", "-fv", dev]
-    if supports_discard:
-        result = run(discard_args, check=False, timeout=360.0)
-        discard_info = {
-            "args": discard_args,
-            "rc": result.rc,
-            "stdout": (result.out or "").strip(),
-            "stderr": (result.err or "").strip(),
-        }
-        wipe_info["blkdiscard"] = discard_info
-        if result.rc != 0:
-            trace(
-                "mounts.blkdiscard_failed",
-                device=dev,
-                rc=result.rc,
-                stderr=discard_info["stderr"],
-                stdout=discard_info["stdout"],
-            )
-            dd_info = _dd_zero_first_megabytes(dev)
-            wipe_info["dd_zero"] = dd_info
-            if dd_info["rc"] != 0:
-                state = {**_collect_device_state(dev), "wipe": wipe_info}
-                detail = dd_info.get("stderr") or dd_info.get("stdout") or f"rc {dd_info['rc']}"
-                raise MkfsError(
-                    f"zeroing {dev} failed: {detail}",
-                    state=state,
-                )
-    else:
-        trace("mounts.discard_unsupported", device=dev, capabilities=capabilities)
-        dd_info = _dd_zero_first_megabytes(dev)
-        wipe_info["dd_zero"] = dd_info
-        if dd_info["rc"] != 0:
-            state = {**_collect_device_state(dev), "wipe": wipe_info}
-            detail = dd_info.get("stderr") or dd_info.get("stdout") or f"rc {dd_info['rc']}"
-            raise MkfsError(
-                f"zeroing {dev} failed: {detail}",
-                state=state,
-            )
-
-    return wipe_info
-
-
-def _dmesg_tail(lines: int = 120) -> list[str] | None:
-    try:
-        result = run(["dmesg", "-T"], check=False, timeout=10.0)
-    except FileNotFoundError:
-        trace("mounts.dmesg_missing")
-        return None
-    output = (result.out or "").splitlines()
-    if not output:
-        return []
-    return output[-lines:]
-
-
-def _lsblk_discard(dev: str) -> str | None:
-    try:
-        result = run(["lsblk", "-D", dev], check=False, timeout=10.0)
-    except FileNotFoundError:
-        trace("mounts.lsblk_missing")
-        return None
-    return (result.out or "").strip()
-
-
-def _dmsetup_table_snapshot(dev: str) -> dict | None:
-    try:
-        result = run(["dmsetup", "table", dev], check=False, timeout=10.0)
-    except FileNotFoundError:
-        trace("mounts.dmsetup_missing")
-        return {"error": "dmsetup not found"}
-    return {
-        "rc": result.rc,
-        "stdout": (result.out or "").strip(),
-        "stderr": (result.err or "").strip(),
-    }
-
-
-def _mkfs(dev: str, fstype: str, label: str | None):
-    state = _collect_device_state(dev)
-    state["fstype"] = fstype
-    errors = _preflight_errors(state)
-    if errors:
-        raise MkfsError(
-            f"refusing to format {dev}: " + "; ".join(errors),
-            state=state,
-        )
-
-    try:
-        wipe_info = _wipe_device(dev)
-    except MkfsError as exc:
-        exc_state = dict(exc.state or {})
-        exc_state.setdefault("fstype", fstype)
-        exc.state = exc_state
-        raise
-
-    args = [f"mkfs.{fstype}"]
-    if fstype == "ext4":
-        args += ["-F", "-E", "lazy_journal_init=1"]
-    if label:
-        if fstype == "vfat":
-            args += ["-n", label]
-        else:
-            args += ["-L", label]
-
-    attempts: list[dict[str, str | int]] = []
-    delay = 0.5
-    extra_variants: list[list[str]]
-    if fstype == "ext4":
-        extra_variants = [[], ["-O", "^metadata_csum_seed"]]
-    else:
-        extra_variants = [[]]
-    for attempt in range(3):
-        extra = extra_variants[min(attempt, len(extra_variants) - 1)]
-        cmd = args + extra + [dev]
-        try:
-            run(cmd, check=True, timeout=360.0)
-            trace("mounts.mkfs_success", device=dev, fstype=fstype, attempts=attempt + 1)
-            return
-        except CalledProcessError as exc:
-            msg = (exc.stderr or exc.stdout or "").strip() or f"exit status {exc.returncode}"
-            attempts.append({
-                "rc": exc.returncode,
-                "stderr": (exc.stderr or "").strip(),
-                "stdout": (exc.stdout or "").strip(),
-                "message": msg,
-                "args": cmd,
-            })
-            trace(
-                "mounts.mkfs_retry",
-                device=dev,
-                fstype=fstype,
-                attempt=attempt + 1,
-                rc=exc.returncode,
-                stderr=(exc.stderr or "").strip(),
-            )
-            if attempt == 2:
-                break
-            udev_settle()
-            time.sleep(delay)
-            delay = min(4.0, delay * 2)
-
-    raise MkfsError(
-        f"mkfs.{fstype} failed on {dev}: {attempts[-1]['message'] if attempts else 'unknown error'}",
-        state={
-            **_collect_device_state(dev),
-            "mkfs_attempts": attempts,
-            "fstype": fstype,
-            "wipe": wipe_info,
-            "diagnostics": {
-                "dmesg_tail": _dmesg_tail(),
-                "lsblk_discard": _lsblk_discard(dev),
-                "dmsetup_table": _dmsetup_table_snapshot(dev),
-            },
-        },
-    )
-
-def _ensure_fs(dev: str, fstype: str, label: str | None=None):
-    _await_block_device(dev, timeout=15.0)
-    cur = _blkid_type(dev)
+def _ensure_fs(dev: str, fstype: str, label: str = None):
+    cur = _blkid(dev)
     if cur == fstype:
         return
-    _mkfs(dev, fstype, label)
-
-def _mount(dev: str, target: str, fstype: str | None=None, opts: list[str] | None=None):
-    run(["mkdir","-p", target], check=True)
-    cmd = ["mount"]
-    if fstype: cmd += ["-t", fstype]
-    if opts: cmd += ["-o", ",".join(opts)]
-    cmd += [dev, target]
-    run(cmd, check=True)
-
-def _umount_all(paths: list[str]):
-    for p in reversed(paths):
-        run(["umount","-l", p], check=False)
+    if fstype == "vfat":
+        args = ["mkfs.vfat","-F","32"]
+        if label: args += ["-n", label]
+        run(args + [dev], check=True, timeout=60.0)
+    elif fstype == "ext4":
+        args = ["mkfs.ext4","-F"]
+        if label: args += ["-L", label]
+        # pre-clean stale signatures and let udev settle
+        run(["wipefs", "-a", dev], check=True, timeout=60.0)
+        run(["udevadm", "settle"], check=True, timeout=60.0)
+        run(args + [dev], check=True, timeout=360.0)
+    else:
+        raise SystemExit(f"Unsupported mkfs type: {fstype}")
     udev_settle()
 
-def _root_lv_path(dm: DeviceMap) -> str:
-    """Return the mapper path backing the root logical volume.
+def _mount(dev: str, dirpath: str, opts: list[str] = None):
+    run(["mkdir","-p", dirpath], check=False)
+    cmd = ["mount"]
+    if opts: cmd += ["-o", ",".join(opts)]
+    cmd += [dev, dirpath]
+    run(cmd, check=True)
+    udev_settle()
 
-    Historically the path was hard-coded throughout the provisioning
-    workflow.  Centralising the computation makes it easier to support
-    alternative volume group or logical volume names in the future and keeps
-    the mount helpers in sync with the probing logic.
-    """
-
-    root_path = getattr(dm, "root_lv_path", None)
-    if root_path:
-        return root_path
-    if dm.vg and dm.lv:
-        return f"/dev/mapper/{dm.vg}-{dm.lv}"
-    raise SystemExit("unable to determine root logical volume path from device map")
-
-
-def _is_block_device(path: str) -> bool:
-    try:
-        st = os.stat(path)
-    except FileNotFoundError:
-        return False
-    except OSError as exc:  # noqa: PERF203 - surface unexpected stat failures
-        trace("mounts.stat_error", path=path, error=str(exc))
-        return False
-    return stat.S_ISBLK(st.st_mode)
-
-
-def _root_lv_exists(dm: DeviceMap) -> bool:
-    """Return ``True`` when the root logical volume path is available.
-
-    When verifying an existing installation the logical volume may already be
-    active before the provisioning helpers get a chance to run ``vgchange``.
-    ``lsblk`` provides the mapper path in that situation, so prefer the
-    explicit ``root_lv_path`` attribute from the device map when present and
-    fall back to deriving the path from the volume group and logical volume
-    names.  Any ``SystemExit`` raised by :func:`_root_lv_path` bubbles up so
-    callers can handle missing metadata consistently.
-    """
-
-    root_path = dm.root_lv_path or _root_lv_path(dm)
-    return bool(root_path) and _is_block_device(root_path)
-
-
-def _await_block_device(path: str, timeout: float = 10.0, settle: bool = True) -> None:
-    """Wait until ``path`` resolves to a block device.
-
-    Device-mapper nodes can take a short while to appear after LVM commands
-    return.  Poll the filesystem for up to ``timeout`` seconds, asking udev to
-    settle between attempts so follow-up operations (``mkfs``, ``mount``) do
-    not fail spuriously.
-    """
-
-    deadline = time.monotonic() + timeout
-    trace("mounts.await_block.start", path=path, timeout=timeout)
-    while True:
-        if _is_block_device(path):
-            trace("mounts.await_block.ready", path=path)
-            return
-        now = time.monotonic()
-        if now >= deadline:
-            break
-        trace("mounts.await_block.retry", path=path, remaining=max(0.0, deadline - now))
-        if settle:
-            udev_settle()
-        time.sleep(0.1)
-
-    if not os.path.exists(path):
-        raise RuntimeError(
-            f"block device {path!r} did not appear within {timeout:.1f}s"
-        )
-    raise RuntimeError(f"{path!r} exists but is not a block device")
-
-
-def _activate_vg(dm: DeviceMap):
-    """Ensure the volume group backing ``dm`` is active.
-
-    ``vgchange`` occasionally fails with ``exit status 5`` immediately after
-    the LUKS container is opened because the LVM metadata cache has not been
-    refreshed yet.  Retry once after forcing a metadata scan so the
-    post-check-only flow can continue rather than crashing.
-    """
-
-    if not dm.vg:
-        return
-
-    def _do_activate():
-        run(["vgchange", "-ay", dm.vg], check=True)
-
-    try:
-        if _root_lv_exists(dm):
-            return
-        _do_activate()
-    except CalledProcessError as exc:
-        if exc.returncode != 5:
-            raise
-        trace(
-            "mounts.vgchange_retry",
-            vg=dm.vg,
-            rc=exc.returncode,
-            stderr=(exc.stderr or "").strip(),
-        )
-        run(["pvscan", "--cache"], check=False)
-        run(["vgscan", "--cache"], check=False)
-        try:
-            if _root_lv_exists(dm):
-                return
-            _do_activate()
-        except CalledProcessError as retry_exc:
-            if _root_lv_exists(dm):
-                return
-            msg = retry_exc.stderr or retry_exc.stdout or str(retry_exc)
-            raise RuntimeError(
-                f"failed to activate volume group {dm.vg!r}: {msg.strip()}"
-            ) from retry_exc
-
-
-def mount_targets(device: str, dry_run: bool=False, destructive: bool=True) -> Mounts:
-    dm: DeviceMap = probe(device, dry_run=dry_run)
+def mount_targets(device: str, dry_run: bool=False) -> Mounts:
+    dm = probe(device, dry_run=dry_run)
     mnt = "/mnt/nvme"
     boot = f"{mnt}/boot"
     esp = f"{boot}/firmware"
-    run(["mkdir","-p", mnt, boot, esp], check=True)
-    # Bring the volume group online before touching any of the logical
-    # volumes.  This ensures the mapper path is available even when the VG is
-    # inactive (for example when provisioning over an existing install where
-    # ``vgcreate``/``lvcreate`` are no-ops).
-    _activate_vg(dm)
-    root_lv = _root_lv_path(dm)
-    _await_block_device(root_lv, timeout=15.0)
-    udev_settle()
-    # ensure fs only when destructive
-    if destructive:
-        _ensure_fs(dm.p1, "vfat", label="EFI")
-        _ensure_fs(dm.p2, "ext4", label="boot")
-        _ensure_fs(root_lv, "ext4", label="root")
-    # mount (ro when non-destructive)
-    ro_opts = ["ro"] if not destructive else None
-    _mount(root_lv, mnt, fstype="ext4", opts=ro_opts)
-    _mount(dm.p2, boot, fstype="ext4", opts=ro_opts)
-    #_mount(dm.p1, esp, fstype="vfat", opts=(ro_opts or ["umask=0077"]))  # keep umask on rw too
-    # Keep the ESP permissions tight even on read-only verification mounts.
-    esp_opts = ["umask=0077"]
-    if ro_opts:
-        esp_opts = ro_opts + esp_opts
-    _mount(dm.p1, esp, fstype="vfat", opts=esp_opts)
+
+    # Ensure filesystems exist
+    _ensure_fs(dm.p1, "vfat", label="EFI")
+    _ensure_fs(dm.p2, "ext4", label="boot")
+    # Root LV is fixed name
+    root_dev = "/dev/mapper/rp5vg-root"
+    _ensure_fs(root_dev, "ext4", label="root" )
+
+    # Mount in correct order
+    _mount(root_dev, mnt)
+    _mount(dm.p2, boot)
+    _mount(dm.p1, esp, opts=["umask=0077"])  # secure ESP
     return Mounts(mnt=mnt, boot=boot, esp=esp)
 
-def _findmnt_source(path: str) -> str:
-    r = run(["findmnt","-no","SOURCE", path], check=False)
-    return (getattr(r, "out", "") or "").strip()
 
-def bind_mounts(mnt: str, read_only: bool = False):
-    # Bind basic system dirs into target root; remount ro if requested
-    for p in ("dev", "proc", "sys", "run"):
-        src = f"/{p}"
-        dst = f"{mnt}/{p}"
-        run(["mkdir","-p", dst], check=True)
-        # Use --bind for consistency even for proc/sys; sufficient for verification flows
-        run(["mount","--bind", src, dst], check=True)
-        if read_only:
-            run(["mount","-o","remount,ro", dst], check=False)
+def bind_mounts(mnt: str, dry_run: bool=False):
+    # Ensure necessary mountpoints exist before bind-mounting
+    for sub in ("/dev", "/proc", "/sys", "/run"):
+        run(["mkdir","-p", f"{mnt}{sub}"], check=False, dry_run=dry_run)
+    # Bind the live system dirs into the target for chroot operations
+    for p in ("/dev","/proc","/sys","/run"):
+        trace("bind_mount", src=p, dst=f"{mnt}{p}")
+        run(["mount","--bind", p, f"{mnt}{p}"], check=False, dry_run=dry_run)
 
-def unmount_all(mnt: str, boot: str | None = None, esp: str | None = None):
-    # Unmount in reverse order; be lazy to avoid hard failures
-    paths = [f"{mnt}/dev/pts", f"{mnt}/dev", f"{mnt}/proc", f"{mnt}/sys", f"{mnt}/run"]
-    if esp: paths.append(esp)
-    if boot: paths.append(boot)
-    paths.append(mnt)
-    for p in paths:
+
+def unmount_all(mnt: str, force: bool=True, dry_run: bool=False):
+    run(["sync"], check=False)
+    for p in ("/proc","/sys","/dev"):
+        run(["umount","-l", f"{mnt}{p}"], check=False)
+    for p in (f"{mnt}/boot/firmware", f"{mnt}/boot", mnt):
         run(["umount","-l", p], check=False)
     udev_settle()
 
-def assert_mount_sources(dm: DeviceMap, mnt: str, boot: str, esp: str):
-    # Compare actual mount backing devices vs expected from probe
-    root_exp = _root_lv_path(dm)
-    mnt_src = _findmnt_source(mnt)
-    boot_src = _findmnt_source(boot)
-    esp_src  = _findmnt_source(esp)
+
+
+def assert_mount_sources(mnt: str, boot: str, esp: str, root_dev: str, boot_dev: str, esp_dev: str):
+    def src(path):
+        out = (run(["findmnt","-no","SOURCE", path], check=False).out or "")
+        # findmnt sometimes prints extra newlines in stacked bind cases; pick the last non-empty line
+        lines = [l.strip() for l in out.splitlines() if l.strip()]
+        return lines[-1] if lines else ""
+
+    def canon(dev):
+        out = (run(["readlink","-f", dev], check=False).out or "").strip()
+        return out if out else dev
+
+    def uuid(dev):
+        c = canon(dev)
+        r = run(["blkid","-s","UUID","-o","value", c], check=False)
+        txt = (r.out or "").strip()
+        return txt
+
+    s_root, s_boot, s_esp = src(mnt), src(boot), src(esp)
+
+    # Quick exact equality short-circuit
+    if s_root == root_dev and s_boot == boot_dev and s_esp == esp_dev:
+        return
+
+    pairs = [
+        ("root", s_root, root_dev),
+        ("boot", s_boot, boot_dev),
+        ("esp",  s_esp,  esp_dev),
+    ]
+
     mismatches = []
-    if mnt_src and mnt_src != root_exp:
-        mismatches.append(("root", mnt_src, root_exp))
-    if boot_src and boot_src != dm.p2:
-        mismatches.append(("boot", boot_src, dm.p2))
-    if esp_src and esp_src != dm.p1:
-        mismatches.append(("esp", esp_src, dm.p1))
+    for label, actual, expected in pairs:
+        a_can, e_can = canon(actual), canon(expected)
+        if a_can == e_can:
+            continue
+        a_uuid, e_uuid = uuid(actual), uuid(expected)
+        if a_uuid and e_uuid and a_uuid == e_uuid:
+            continue
+        mismatches.append((label, actual, expected, a_can, e_can, a_uuid, e_uuid))
+
     if mismatches:
-        parts = [f"{label}: actual={a} expected={e}" for (label,a,e) in mismatches]
+        parts = []
+        for label, a, e, ac, ec, au, eu in mismatches:
+            parts.append(f"{label}: actual={a} expected={e} | canon={ac} vs {ec} | uuid={au} vs {eu}")
         raise SystemExit("mount sources mismatch: " + " ; ".join(parts))
-
-def _umount(path:str):
-    import subprocess
-    subprocess.call(["umount","-Rfl", path])
-
-def unmount_tracked(ms: "MountSet"):
-    # Unmount binds first, then mounts in reverse
-    for p in reversed(ms.binds):
-        _umount(p)
-    for p in reversed(ms.mounted_paths):
-        _umount(p)
-
-class MountSet:
-    def __init__(self, mnt:str):
-        self.mnt = mnt
-        self.mounted_paths = []
-        self.binds = []

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1,152 +1,115 @@
-import subprocess
-from unittest import mock
+from types import SimpleNamespace
 
 import pytest
 
 from provision import mounts
 
 
-def test_await_block_device_retries_until_ready(monkeypatch):
-    calls: list[str] = []
-
-    def fake_is_block(path: str) -> bool:
-        calls.append(path)
-        return len(calls) >= 3
-
-    monotonic_values = iter([0.0, 0.0, 0.1, 0.2])
-
-    monkeypatch.setattr(mounts, "_is_block_device", fake_is_block)
-    monkeypatch.setattr(mounts.time, "monotonic", lambda: next(monotonic_values))
-    monkeypatch.setattr(mounts, "udev_settle", lambda: None)
-    monkeypatch.setattr(mounts.time, "sleep", lambda _: None)
-
-    mounts._await_block_device("/dev/mapper/test", timeout=1.0)
-
-    assert calls == ["/dev/mapper/test"] * 3
+class DummyResult:
+    def __init__(self, out: str = "") -> None:
+        self.out = out
 
 
-def test_await_block_device_missing(monkeypatch):
-    monotonic_values = iter([0.0, 1.1])
-
-    monkeypatch.setattr(mounts, "_is_block_device", lambda path: False)
-    monkeypatch.setattr(mounts.time, "monotonic", lambda: next(monotonic_values))
-    monkeypatch.setattr(mounts, "udev_settle", lambda: None)
-    monkeypatch.setattr(mounts.time, "sleep", lambda _: None)
-    monkeypatch.setattr(mounts.os.path, "exists", lambda path: False)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        mounts._await_block_device("/dev/mapper/miss", timeout=1.0)
-
-    assert "did not appear" in str(excinfo.value)
-
-
-def test_await_block_device_wrong_type(monkeypatch):
-    monotonic_values = iter([0.0, 1.1])
-
-    monkeypatch.setattr(mounts, "_is_block_device", lambda path: False)
-    monkeypatch.setattr(mounts.time, "monotonic", lambda: next(monotonic_values))
-    monkeypatch.setattr(mounts, "udev_settle", lambda: None)
-    monkeypatch.setattr(mounts.time, "sleep", lambda _: None)
-    monkeypatch.setattr(mounts.os.path, "exists", lambda path: True)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        mounts._await_block_device("/dev/mapper/notblk", timeout=1.0)
-
-    assert "not a block device" in str(excinfo.value)
-
-
-def test_mkfs_raises_mkfs_error(monkeypatch):
-    calls: list[list[str]] = []
-
-    class DummyResult:
-        def __init__(self, rc: int = 0, out: str = "", err: str = "") -> None:
-            self.rc = rc
-            self.out = out
-            self.err = err
-
-    def fake_run(cmd, check=True, timeout=0.0, **_kwargs):  # noqa: ARG001 - signature matches executil.run
-        calls.append(cmd)
-        if cmd[0] == "wipefs":
-            return DummyResult()
-        if cmd[0] == "blkdiscard":
-            return DummyResult()
-        if cmd[0] == "mkfs.ext4":
-            raise subprocess.CalledProcessError(1, cmd, output="", stderr="boom")
-        raise AssertionError(f"unexpected command {cmd}")
-
-    monkeypatch.setattr(mounts, "run", fake_run)
-    monkeypatch.setattr(
-        mounts,
-        "_collect_device_state",
-        lambda dev: {
-            "device": dev,
-            "mountpoints": [],
-            "holders": [],
-            "read_only": False,
-            "discard_capabilities": {"supports_discard": True},
-        },
-    )
-    monkeypatch.setattr(mounts, "_device_discard_capabilities", lambda dev: {"supports_discard": True})
-    monkeypatch.setattr(mounts, "_dmesg_tail", lambda lines=120: ["tail"])  # noqa: ARG005
-    monkeypatch.setattr(mounts, "_lsblk_discard", lambda dev: "lsblk")
-    monkeypatch.setattr(mounts, "_dmsetup_table_snapshot", lambda dev: {"rc": 0, "stdout": "", "stderr": ""})
-    monkeypatch.setattr(mounts, "udev_settle", lambda: None)
-    monkeypatch.setattr(mounts.time, "sleep", lambda *_: None)
-
-    with pytest.raises(mounts.MkfsError) as excinfo:
-        mounts._mkfs("/dev/mapper/root", "ext4", label="root")
-
-    assert "mkfs.ext4 failed on /dev/mapper/root: boom" in str(excinfo.value)
-    assert excinfo.value.state["mkfs_attempts"]
-    assert calls[0][:2] == ["wipefs", "-a"]
-    assert excinfo.value.state["wipe"]["blkdiscard"]["rc"] == 0
-
-
-def test_wipe_device_uses_dd_fallback(monkeypatch):
+def test_mount_targets_formats_and_mounts(monkeypatch):
     commands: list[list[str]] = []
 
-    class DummyResult:
-        def __init__(self, rc: int = 0, out: str = "", err: str = "") -> None:
-            self.rc = rc
-            self.out = out
-            self.err = err
-
-    def fake_run(cmd, check=True, timeout=0.0, **_kwargs):  # noqa: ARG001
+    def fake_run(cmd, check=True, **_kwargs):  # noqa: ARG001 - signature compatibility
         commands.append(cmd)
-        if cmd[0] == "wipefs":
-            return DummyResult()
-        if cmd[0] == "blkdiscard":
-            return DummyResult(rc=1, err="unsupported")
-        if cmd[0] == "dd":
-            return DummyResult()
-        raise AssertionError(f"unexpected command {cmd}")
+        return DummyResult("")
 
     monkeypatch.setattr(mounts, "run", fake_run)
-    monkeypatch.setattr(mounts, "_collect_device_state", lambda dev: {"device": dev})
-    monkeypatch.setattr(mounts, "_device_discard_capabilities", lambda dev: {"supports_discard": True})
-
-    info = mounts._wipe_device("/dev/mapper/root")
-
-    assert any(cmd[0] == "dd" for cmd in commands)
-    assert info["dd_zero"]["rc"] == 0
-
-
-def test_mkfs_preflight_blocks_busy_device(monkeypatch):
-    run_mock = mock.Mock(side_effect=AssertionError("run should not be called when preflight fails"))
-    monkeypatch.setattr(mounts, "run", run_mock)
+    monkeypatch.setattr(mounts, "udev_settle", lambda: None)
     monkeypatch.setattr(
         mounts,
-        "_collect_device_state",
-        lambda dev: {
-            "device": dev,
-            "mountpoints": ["/mnt/inuse"],
-            "holders": [],
-            "read_only": False,
-        },
+        "_blkid",
+        lambda dev: "ext4" if dev == "/dev/mapper/rp5vg-root" else "",
+    )
+    monkeypatch.setattr(
+        mounts,
+        "probe",
+        lambda device, dry_run=False: SimpleNamespace(p1="/dev/p1", p2="/dev/p2"),
     )
 
-    with pytest.raises(mounts.MkfsError) as excinfo:
-        mounts._mkfs("/dev/mapper/root", "ext4", label="root")
+    result = mounts.mount_targets("/dev/nvme0n1")
 
-    assert "refusing to format" in str(excinfo.value)
-    run_mock.assert_not_called()
+    assert result.mnt == "/mnt/nvme"
+    assert result.boot == "/mnt/nvme/boot"
+    assert result.esp == "/mnt/nvme/boot/firmware"
+
+    assert ["mkfs.vfat", "-F", "32", "-n", "EFI", "/dev/p1"] in commands
+    assert ["mkfs.ext4", "-F", "-L", "boot", "/dev/p2"] in commands
+    assert ["mount", "/dev/mapper/rp5vg-root", "/mnt/nvme"] in commands
+    assert ["mount", "/dev/p2", "/mnt/nvme/boot"] in commands
+    assert ["mount", "-o", "umask=0077", "/dev/p1", "/mnt/nvme/boot/firmware"] in commands
+
+
+def test_bind_mounts_respects_dry_run(monkeypatch):
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run(cmd, check=True, dry_run=False, **_kwargs):  # noqa: ARG001
+        calls.append((cmd, dry_run))
+        return DummyResult("")
+
+    monkeypatch.setattr(mounts, "run", fake_run)
+    monkeypatch.setattr(mounts, "trace", lambda *args, **kwargs: None)
+
+    mounts.bind_mounts("/target", dry_run=True)
+
+    mkdir_calls = [cmd for cmd, _ in calls if cmd and cmd[0] == "mkdir"]
+    assert mkdir_calls
+    assert all(dry_run for _cmd, dry_run in calls[: len(mkdir_calls)])
+
+    bind_calls = [entry for entry in calls if entry[0][0] == "mount"]
+    assert bind_calls
+    assert all(entry[1] for entry in bind_calls)
+
+
+def test_unmount_all_unmounts_expected_paths(monkeypatch):
+    commands: list[list[str]] = []
+
+    def fake_run(cmd, check=True, **_kwargs):  # noqa: ARG001
+        commands.append(cmd)
+        return DummyResult("")
+
+    monkeypatch.setattr(mounts, "run", fake_run)
+    monkeypatch.setattr(mounts, "udev_settle", lambda: None)
+
+    mounts.unmount_all("/mnt/test")
+
+    assert commands[0] == ["sync"]
+    assert ["umount", "-l", "/mnt/test/proc"] in commands
+    assert ["umount", "-l", "/mnt/test/sys"] in commands
+    assert ["umount", "-l", "/mnt/test/dev"] in commands
+    assert ["umount", "-l", "/mnt/test/boot/firmware"] in commands
+    assert ["umount", "-l", "/mnt/test/boot"] in commands
+    assert ["umount", "-l", "/mnt/test"] in commands
+
+
+def test_assert_mount_sources_detects_mismatch(monkeypatch):
+    def fake_run(cmd, check=True, **_kwargs):  # noqa: ARG001
+        if cmd[0] == "findmnt":
+            mapping = {
+                "/mnt/nvme": "/dev/mapper/actual-root\n",
+                "/mnt/nvme/boot": "/dev/mapper/wrong-boot\n",
+                "/mnt/nvme/boot/firmware": "/dev/mapper/actual-esp\n",
+            }
+            return DummyResult(mapping[cmd[-1]])
+        if cmd[0] == "readlink":
+            return DummyResult(cmd[-1])
+        if cmd[0] == "blkid":
+            return DummyResult("UUID-1234" if "wrong-boot" not in cmd[-1] else "UUID-mismatch")
+        return DummyResult("")
+
+    monkeypatch.setattr(mounts, "run", fake_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        mounts.assert_mount_sources(
+            "/mnt/nvme",
+            "/mnt/nvme/boot",
+            "/mnt/nvme/boot/firmware",
+            "/dev/mapper/expected-root",
+            "/dev/mapper/expected-boot",
+            "/dev/mapper/expected-esp",
+        )
+
+    assert "boot" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- update the provisioning CLI to use the reverted mount helper signatures and drop MkfsError handling
- remove the later _ensure_fs override so mounts.py matches the Phase 5.1 behavior
- rewrite the mount helper tests to exercise the simplified contract and dry-run behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e51a8b9afc832fb2209f0bd0f69396