### PR TITLE
Make postcheck mounts non-destructive

### DIFF
--- a/provision/cli.py
+++ b/provision/cli.py
@@ -464,7 +464,7 @@ def _run_postcheck_only(plan: ProvisionPlan, flags: Flags, passphrase_file: str)
     dm = probe(plan.device)
     mounts = None
     open_luks(dm.p3, dm.luks_name, passphrase_file)
-    mounts = mount_targets(dm.device, dry_run=False)
+    mounts = mount_targets(dm.device, dry_run=False, destructive=False)
     bind_mounts(mounts.mnt)
     try:
         p1_uuid = uuid_of(dm.p1)


### PR DESCRIPTION
## Summary
- make `mount_targets` support a non-destructive mode that only verifies existing filesystems
- use the non-destructive mounts when running the postcheck-only workflow
- cover the read-only mode with a dedicated unit test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5352b5a58832f8eab872d1646eb96