### PR TITLE
Add Python verification helpers for NVMe postcheck

### DIFF
--- a/provision/verification.py
+++ b/provision/verification.py
@@ -1,5 +1,5 @@
 
-import os, subprocess, json, shlex
+import os, subprocess, json, shlex, re, glob
 
 _PRIVILEGED_BINARIES = {"cryptsetup"}
 
@@ -36,6 +36,167 @@ def _read(path):
             return f.read()
     except Exception as e:
         return f"<read-failed: {e}>"
+
+
+def _canon(path: str) -> str:
+    try:
+        return os.path.realpath(path)
+    except Exception:
+        return path
+
+
+def _first_line(text: str) -> str:
+    if not text:
+        return ""
+    return text.splitlines()[0].strip()
+
+
+def _command_output(cmd: list[str]) -> str:
+    res = _run(cmd, check=False)
+    if res.get("rc", 1) == 0 and res.get("out"):
+        return _first_line(res["out"])
+    return ""
+
+
+def _findmnt_source(mountpoint: str) -> str:
+    res = _run(["findmnt", "-no", "SOURCE", mountpoint], check=True)
+    if res.get("rc") != 0 or not res.get("out"):
+        raise RuntimeError(f"unable to determine source for mountpoint: {mountpoint}")
+    return _first_line(res["out"])
+
+
+def _fstype_of(device: str) -> str:
+    for cmd in (["blkid", "-s", "TYPE", "-o", "value", device], ["lsblk", "-no", "FSTYPE", device]):
+        out = _command_output(cmd)
+        if out:
+            return out
+    return ""
+
+
+def _uuid_of(device: str) -> str:
+    for cmd in (["blkid", "-s", "UUID", "-o", "value", device], ["lsblk", "-no", "UUID", device]):
+        out = _command_output(cmd)
+        if out:
+            return out
+    return ""
+
+
+def verify_sources(
+    root_mount: str,
+    boot_mount: str,
+    esp_mount: str,
+    expected_root: str,
+    expected_boot: str,
+    expected_esp: str,
+) -> dict:
+    result = {"ok": True, "sources": {}}
+    checks = (
+        ("root", root_mount, expected_root),
+        ("boot", boot_mount, expected_boot),
+        ("esp", esp_mount, expected_esp),
+    )
+    for label, mountpoint, expected in checks:
+        actual_source = _canon(_findmnt_source(mountpoint))
+        expected_source = _canon(expected)
+        matches = actual_source == expected_source
+        result["sources"][label] = {
+            "mountpoint": mountpoint,
+            "actual": actual_source,
+            "expected": expected_source,
+            "matches": matches,
+        }
+        if not matches:
+            raise RuntimeError(f"{label} source mismatch: {actual_source} vs {expected_source}")
+    return result
+
+
+def verify_fs_and_uuid(
+    p1: str,
+    p2: str,
+    p3: str,
+    exp_uuid_p1: str | None = None,
+    exp_uuid_p2: str | None = None,
+    exp_uuid_luks: str | None = None,
+) -> dict:
+    result = {
+        "ok": True,
+        "warnings": [],
+        "partitions": {},
+    }
+
+    f1 = _fstype_of(p1)
+    f2 = _fstype_of(p2)
+    u1 = _uuid_of(p1)
+    u2 = _uuid_of(p2)
+    ul = _uuid_of(p3)
+
+    if f1 != "vfat":
+        raise RuntimeError(f"p1 fstype expected vfat got {f1 or 'none'}")
+    if f2 != "ext4":
+        raise RuntimeError(f"p2 fstype expected ext4 got {f2 or 'none'}")
+
+    result["partitions"]["p1"] = {"fstype": f1, "uuid": u1, "expected_uuid": exp_uuid_p1}
+    result["partitions"]["p2"] = {"fstype": f2, "uuid": u2, "expected_uuid": exp_uuid_p2}
+    result["partitions"]["luks"] = {"uuid": ul, "expected_uuid": exp_uuid_luks}
+
+    if exp_uuid_p1 and u1 != exp_uuid_p1:
+        result["warnings"].append(f"p1 uuid differs: {u1} vs {exp_uuid_p1}")
+    if exp_uuid_p2 and u2 != exp_uuid_p2:
+        result["warnings"].append(f"p2 uuid differs: {u2} vs {exp_uuid_p2}")
+    if exp_uuid_luks and ul != exp_uuid_luks:
+        result["warnings"].append(f"luks uuid differs: {ul} vs {exp_uuid_luks}")
+
+    return result
+
+
+def verify_triplet(
+    mnt_root: str,
+    esp_subdir: str,
+    vg_name: str,
+    lv_name: str,
+    expected_luks_uuid: str | None = None,
+) -> dict:
+    result = {
+        "ok": True,
+        "warnings": [],
+    }
+
+    cmd_path = os.path.join(mnt_root, esp_subdir, "cmdline.txt")
+    crypttab_path = os.path.join(mnt_root, "etc", "crypttab")
+    fstab_path = os.path.join(mnt_root, "etc", "fstab")
+    esp_dir = os.path.join(mnt_root, esp_subdir)
+
+    for path in (cmd_path, crypttab_path, fstab_path):
+        if not os.path.exists(path):
+            raise RuntimeError(f"missing required file: {path}")
+
+    cmd_text = _read(cmd_path)
+    if expected_luks_uuid:
+        token = f"cryptdevice=UUID={expected_luks_uuid}:cryptroot"
+        if token not in cmd_text:
+            result["warnings"].append("cmdline cryptdevice does not match expected LUKS UUID")
+    if "root=/dev/mapper/" not in cmd_text:
+        result["warnings"].append("cmdline missing root mapper token")
+    result["cmdline"] = {"path": cmd_path, "text": cmd_text}
+
+    crypttab_text = _read(crypttab_path)
+    if not re.search(r"^cryptroot\s+UUID=", crypttab_text, re.M):
+        raise RuntimeError("crypttab missing cryptroot line")
+    result["crypttab"] = {"path": crypttab_path, "text": crypttab_text}
+
+    fstab_text = _read(fstab_path)
+    mapper_pattern = rf"/dev/mapper/{re.escape(vg_name)}-{re.escape(lv_name)}\s+/\s+ext4"
+    if not re.search(mapper_pattern, fstab_text):
+        raise RuntimeError("fstab missing root mapper line")
+    result["fstab"] = {"path": fstab_path, "text": fstab_text}
+
+    initramfs_glob = os.path.join(esp_dir, "initramfs_*")
+    initramfs_matches = glob.glob(initramfs_glob)
+    if not initramfs_matches:
+        raise RuntimeError("initramfs image missing under ESP")
+    result["initramfs"] = {"matches": initramfs_matches}
+
+    return result
 
 def nvme_boot_verification(device, esp_mb=None, boot_mb=None, passphrase_file=None, mnt_root="/mnt/nvme", mnt_esp="/mnt/esp"):
     res = {"steps": [], "ok": True}


### PR DESCRIPTION
## Summary
- add Python helpers that mirror the manual NVMe verification script
- validate mount sources, filesystem types, and firmware triplet from Python
- cover the new helpers with unit tests for success and failure paths

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e561e7fb8c832fae17e5d8c4d6f4e5