### PR TITLE
Document and automate initramfs rebuild workflow

### DIFF
--- a/01_DOCS/provisioning.md
+++ b/01_DOCS/provisioning.md
@@ -51,6 +51,68 @@ sudo cryptsetup close cryptroot
 - If pre-boot hangs: ensure `config.txt` has an `initramfs <image> followkernel` line; ensure `cryptsetup-initramfs` and `lvm2` are installed in target; rebuild `update-initramfs -u`.
 - If `luksFormat` fails: wipe signatures (`wipefs -a /dev/<p3>`), `blkdiscard` or zero first 16MiB, confirm keyfile path.
 
+## Manual initramfs rebuild (NVMe root)
+
+If you need to refresh the initramfs on a provisioned NVMe target, perform the following inside the installer host. The sequence
+mirrors what the provisioner now automates.
+
+1. **Mount the target and prep the chroot**
+
+   ```bash
+   sudo cryptsetup open /dev/nvme0n1p3 cryptroot
+   sudo vgchange -ay rp5vg
+   sudo mount /dev/mapper/rp5vg-root /mnt/nvme
+   sudo mount /dev/nvme0n1p2 /mnt/nvme/boot
+   sudo mount /dev/nvme0n1p1 /mnt/nvme/boot/firmware
+
+   sudo mkdir -p /mnt/nvme/{dev,dev/pts,proc,sys,tmp}
+   sudo mount --bind /dev     /mnt/nvme/dev
+   sudo mount --bind /dev/pts /mnt/nvme/dev/pts
+   sudo mount -t proc  proc   /mnt/nvme/proc
+   sudo mount -t sysfs sys    /mnt/nvme/sys
+   sudo chmod 1777 /mnt/nvme/tmp
+   sudo cp /etc/resolv.conf /mnt/nvme/etc/resolv.conf
+   ```
+
+2. **Force `crypttab` to prompt in the initramfs**
+
+   ```bash
+   sudo sed -i -E 's|^(cryptroot[[:space:]]+UUID=[0-9a-f-]+)[[:space:]]+\S+|\1 none|' /mnt/nvme/etc/crypttab
+   ```
+
+3. **Rebuild the initramfs for the active kernel and publish it to the ESP**
+
+   ```bash
+   sudo chroot /mnt/nvme bash -lc '
+   set -e
+   kver=$(basename /lib/modules/* | head -n1)
+   apt-get update || true
+   dpkg -s cryptsetup-initramfs >/dev/null 2>&1 || apt-get install -y cryptsetup-initramfs
+   dpkg -s lvm2                 >/dev/null 2>&1 || apt-get install -y lvm2
+   dpkg -s initramfs-tools      >/dev/null 2>&1 || apt-get install -y initramfs-tools
+   update-initramfs -c -k "$kver" || update-initramfs -u -k "$kver"
+   cp -v "/boot/initrd.img-$kver" /boot/firmware/initramfs_2712
+   lsinitramfs /boot/firmware/initramfs_2712 | egrep -i "cryptsetup|dm-crypt|lvm|nvme" | head
+   '
+   ```
+
+4. **Quick triplet check**
+
+   ```bash
+   grep -n 'cryptdevice=UUID=.*:cryptroot' /mnt/nvme/boot/firmware/cmdline.txt
+   grep -n '^cryptroot'                    /mnt/nvme/etc/crypttab
+   grep -n '/dev/mapper/rp5vg-root'        /mnt/nvme/etc/fstab
+   ls -lh /mnt/nvme/boot/firmware/initramfs_2712
+   ```
+
+5. **Cleanly unmount and close**
+
+   ```bash
+   sudo umount -R /mnt/nvme
+   sudo vgchange -an rp5vg
+   sudo cryptsetup close cryptroot
+   ```
+
 
 ### Rsync policy
 - Rsync is **strict by default**: any non-zero exit (including 23/24) aborts the run.

--- a/provision/initramfs.py
+++ b/provision/initramfs.py
@@ -3,13 +3,89 @@
 import os, re, subprocess
 from .executil import run
 
-def ensure_packages(mnt: str, dry_run: bool=False):
-    ch = ["chroot", mnt, "/usr/bin/apt-get", "-y", "update"]
-    run(ch, check=False, dry_run=dry_run)
-    run(["chroot", mnt, "/usr/bin/apt-get", "-y", "install", "cryptsetup-initramfs", "lvm2"], check=False, dry_run=dry_run)
 
-def rebuild(mnt: str, dry_run: bool=False):
-    run(["chroot", mnt, "/usr/sbin/update-initramfs", "-u"], check=False, dry_run=dry_run)
+REQUIRED_PACKAGES = ("cryptsetup-initramfs", "lvm2", "initramfs-tools")
+
+
+def ensure_packages(mnt: str, dry_run: bool = False):
+    """Install initramfs prerequisites inside the target root if missing."""
+
+    run(["chroot", mnt, "/usr/bin/apt-get", "update"], check=False, dry_run=dry_run)
+    for pkg in REQUIRED_PACKAGES:
+        res = run(["chroot", mnt, "/usr/bin/dpkg", "-s", pkg], check=False, dry_run=dry_run)
+        if res.rc != 0:
+            run(
+                ["chroot", mnt, "/usr/bin/apt-get", "-y", "install", pkg],
+                check=False,
+                dry_run=dry_run,
+            )
+
+
+def _ensure_crypttab_prompts(mnt: str) -> None:
+    """Force crypttab to prompt for the passphrase (no baked-in key path)."""
+
+    ct_path = os.path.join(mnt, "etc", "crypttab")
+    if not os.path.isfile(ct_path):
+        return
+    with open(ct_path, "r", encoding="utf-8") as fh:
+        original = fh.read()
+    patched = re.sub(
+        r"^(cryptroot\s+UUID=[0-9a-fA-F-]+)\s+\S+",
+        r"\1 none",
+        original,
+        flags=re.M,
+    )
+    if patched != original:
+        with open(ct_path, "w", encoding="utf-8") as fh:
+            fh.write(patched)
+
+
+def _detect_kernel_version(mnt: str) -> str:
+    modules_dir = os.path.join(mnt, "lib", "modules")
+    if not os.path.isdir(modules_dir):
+        raise RuntimeError("initramfs: /lib/modules missing in target root")
+    cands = [
+        entry
+        for entry in os.listdir(modules_dir)
+        if os.path.isdir(os.path.join(modules_dir, entry))
+    ]
+    if not cands:
+        raise RuntimeError("initramfs: no kernel modules found in target root")
+    return sorted(cands)[0]
+
+
+def rebuild(mnt: str, dry_run: bool = False):
+    _ensure_crypttab_prompts(mnt)
+    kver = _detect_kernel_version(mnt)
+
+    res = run(
+        ["chroot", mnt, "/usr/sbin/update-initramfs", "-c", "-k", kver],
+        check=False,
+        dry_run=dry_run,
+    )
+    if res.rc != 0:
+        run(
+            ["chroot", mnt, "/usr/sbin/update-initramfs", "-u", "-k", kver],
+            check=True,
+            dry_run=dry_run,
+        )
+
+    run(
+        ["chroot", mnt, "/bin/cp", "-f", f"/boot/initrd.img-{kver}", "/boot/firmware/initramfs_2712"],
+        check=True,
+        dry_run=dry_run,
+    )
+    run(
+        [
+            "chroot",
+            mnt,
+            "/usr/bin/lsinitramfs",
+            "/boot/firmware/initramfs_2712",
+        ],
+        check=True,
+        dry_run=dry_run,
+    )
+
 
 def verify(dst_boot_fw: str) -> str:
     cfg = os.path.join(dst_boot_fw, 'config.txt')
@@ -26,8 +102,13 @@ def verify(dst_boot_fw: str) -> str:
         raise RuntimeError("initramfs: image missing or too small")
     # ensure cryptsetup+lvm present
     out = subprocess.check_output(["lsinitramfs", ir], text=True)
-    if "cryptsetup" not in out or "lvm" not in out:
-        raise RuntimeError("initramfs: missing cryptsetup or lvm in image")
+    out_lower = out.lower()
+    required_tokens = ("cryptsetup", "lvm", "dm-crypt", "nvme")
+    missing = [tok for tok in required_tokens if tok not in out_lower]
+    if missing:
+        raise RuntimeError(
+            "initramfs: missing components in image (%s)" % ", ".join(missing)
+        )
     return ir
 
 def newest_initrd(dst_boot_fw: str) -> str:

--- a/provision/verification.py
+++ b/provision/verification.py
@@ -191,7 +191,7 @@ def verify_triplet(
     result["fstab"] = {"path": fstab_path, "text": fstab_text}
 
     initramfs_glob = sorted(glob.glob(os.path.join(mnt_root, "boot", "firmware", "initramfs_*")))
-    initramfs_matches = glob.glob(initramfs_glob)
+    initramfs_matches = initramfs_glob
     if not initramfs_matches:
         raise RuntimeError("initramfs image missing under ESP")
     result["initramfs"] = {"matches": initramfs_matches}


### PR DESCRIPTION
## Summary
- document the end-to-end manual initramfs rebuild procedure in the provisioning guide
- update the initramfs helper to install missing packages, enforce crypttab prompting, rebuild the image, and copy it to the ESP
- fix the verification helper to report discovered initramfs images without re-globbing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e596dcea78832f9462a2190267cf0c